### PR TITLE
integrate metadata extraction into AutoVectorStoreIndex

### DIFF
--- a/autollm/auto/vector_store_index.py
+++ b/autollm/auto/vector_store_index.py
@@ -1,6 +1,14 @@
 from typing import Optional, Sequence
 
 from llama_index import Document, StorageContext, VectorStoreIndex
+from llama_index.node_parser import SimpleNodeParser
+from llama_index.node_parser.extractors import (
+    KeywordExtractor,
+    MetadataExtractor,
+    QuestionsAnsweredExtractor,
+    SummaryExtractor,
+    TitleExtractor,
+)
 
 
 def import_vector_store_class(vector_store_class_name: str):
@@ -25,6 +33,7 @@ class AutoVectorStoreIndex:
     def from_defaults(
             vector_store_type: str = "LanceDBVectorStore",
             documents: Optional[Sequence[Document]] = None,
+            metadata_extraction_enabled: bool = False,
             **kwargs) -> VectorStoreIndex:
         """
         Initializes a Vector Store index from Vector Store type and additional parameters.
@@ -32,6 +41,7 @@ class AutoVectorStoreIndex:
         Parameters:
             vector_store_type (str): The class name of the vector store (e.g., 'LanceDBVectorStore', 'SimpleVectorStore'..)
             documents (Optional[Sequence[Document]]): Documents to initialize the vector store index from.
+            metadata_extraction_enabled (bool): Whether to enable metadata extraction.
             **kwargs: Additional parameters for initializing the vector store
 
         Returns:
@@ -53,7 +63,21 @@ class AutoVectorStoreIndex:
                 kwargs["uri"] = "/tmp/lancedb"
             vector_store = VectorStoreClass(**kwargs)
             storage_context = StorageContext.from_defaults(vector_store=vector_store)
-            index = VectorStoreIndex.from_documents(
-                documents=documents, storage_context=storage_context, show_progress=True)
+
+            if metadata_extraction_enabled:
+                metadata_extractor = MetadataExtractor(
+                    extractors=[
+                        TitleExtractor(nodes=5),
+                        QuestionsAnsweredExtractor(questions=3),
+                        SummaryExtractor(summaries=["prev", "self"]),
+                        KeywordExtractor(keywords=10),
+                    ], )
+                node_parser = SimpleNodeParser.from_defaults(metadata_extractor=metadata_extractor, )
+                nodes = node_parser.get_nodes_from_documents(documents)
+                index = VectorStoreIndex(nodes=nodes, storage_context=storage_context)
+            # Initialize index without metadata extraction
+            else:
+                index = VectorStoreIndex.from_documents(
+                    documents=documents, storage_context=storage_context, show_progress=True)
 
         return index

--- a/autollm/auto/vector_store_index.py
+++ b/autollm/auto/vector_store_index.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from llama_index import Document, StorageContext, VectorStoreIndex
 from llama_index.node_parser import SimpleNodeParser
 from llama_index.node_parser.extractors import (
+    EntityExtractor,
     KeywordExtractor,
     MetadataExtractor,
     QuestionsAnsweredExtractor,
@@ -71,6 +72,7 @@ class AutoVectorStoreIndex:
                         QuestionsAnsweredExtractor(questions=3),
                         SummaryExtractor(summaries=["prev", "self"]),
                         KeywordExtractor(keywords=10),
+                        EntityExtractor(prediction_threshold=0.5)
                     ], )
                 node_parser = SimpleNodeParser.from_defaults(metadata_extractor=metadata_extractor, )
                 nodes = node_parser.get_nodes_from_documents(documents)

--- a/autollm/auto/vector_store_index.py
+++ b/autollm/auto/vector_store_index.py
@@ -34,7 +34,7 @@ class AutoVectorStoreIndex:
     def from_defaults(
             vector_store_type: str = "LanceDBVectorStore",
             documents: Optional[Sequence[Document]] = None,
-            metadata_extraction_enabled: bool = False,
+            enable_metadata_extraction: bool = False,
             **kwargs) -> VectorStoreIndex:
         """
         Initializes a Vector Store index from Vector Store type and additional parameters.
@@ -42,7 +42,7 @@ class AutoVectorStoreIndex:
         Parameters:
             vector_store_type (str): The class name of the vector store (e.g., 'LanceDBVectorStore', 'SimpleVectorStore'..)
             documents (Optional[Sequence[Document]]): Documents to initialize the vector store index from.
-            metadata_extraction_enabled (bool): Whether to enable metadata extraction.
+            enable_metadata_extraction (bool): Whether to enable automated metadata extraction as questions, keywords, entities, or summaries.
             **kwargs: Additional parameters for initializing the vector store
 
         Returns:
@@ -65,7 +65,7 @@ class AutoVectorStoreIndex:
             vector_store = VectorStoreClass(**kwargs)
             storage_context = StorageContext.from_defaults(vector_store=vector_store)
 
-            if metadata_extraction_enabled:
+            if enable_metadata_extraction:
                 metadata_extractor = MetadataExtractor(
                     extractors=[
                         TitleExtractor(nodes=5),


### PR DESCRIPTION
This PR incorporates metadata extraction directly into the `AutoVectorStoreIndex` class, enabling automatic enrichment of documents with metadata for enhanced querying capabilities. The addition is controlled by a simple boolean flag, making the process straightforward and unobtrusive for end-users. The `AutoQueryEngine` class has been minimally adjusted to pass the metadata extraction flag, keeping the API consistent and intuitive.
