### PR TITLE
refactor default embedding selection

### DIFF
--- a/autollm/auto/query_engine.py
+++ b/autollm/auto/query_engine.py
@@ -1,6 +1,7 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from llama_index import Document, ServiceContext, VectorStoreIndex
+from llama_index.embeddings.utils import EmbedType
 from llama_index.indices.query.base import BaseQueryEngine
 
 from autollm.auto.llm import AutoLLM
@@ -14,6 +15,7 @@ def create_query_engine(
         system_prompt: str = None,
         query_wrapper_prompt: str = None,
         enable_cost_calculator: bool = True,
+        embed_model: Optional[EmbedType] = "default",
         llm_params: dict = None,
         vector_store_params: dict = None,
         service_context_params: dict = None,
@@ -26,6 +28,7 @@ def create_query_engine(
         system_prompt (str): The system prompt to use for the query engine.
         query_wrapper_prompt (str): The query wrapper prompt to use for the query engine.
         enable_cost_calculator (bool): Flag to enable cost calculator logging.
+        embed_model (BaseEmbedding): The embedding model to use for the query engine. Defaults to OpenAIEmbedding.
         llm_params (dict): Parameters for the LLM.
         vector_store_params (dict): Parameters for the vector store.
         service_context_params (dict): Parameters for the service context.
@@ -46,6 +49,7 @@ def create_query_engine(
     vector_store_index = AutoVectorStoreIndex.from_defaults(**vector_store_params, documents=documents)
     service_context = AutoServiceContext.from_defaults(
         llm=llm,
+        embed_model=embed_model,
         system_prompt=system_prompt,
         query_wrapper_prompt=query_wrapper_prompt,
         enable_cost_calculator=enable_cost_calculator,

--- a/autollm/auto/service_context.py
+++ b/autollm/auto/service_context.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Union
+from typing import Optional, Union
 
-from llama_index import OpenAIEmbedding, ServiceContext
+from llama_index import ServiceContext
 from llama_index.callbacks import CallbackManager
-from llama_index.embeddings.base import BaseEmbedding
+from llama_index.embeddings.utils import EmbedType
 from llama_index.llms.utils import LLMType
 from llama_index.prompts import PromptTemplate
 from llama_index.prompts.base import BasePromptTemplate
@@ -21,8 +21,8 @@ class AutoServiceContext:
 
     @staticmethod
     def from_defaults(
-            llm: LLMType = "default",
-            embed_model: BaseEmbedding = None,
+            llm: Optional[LLMType] = "default",
+            embed_model: Optional[EmbedType] = "default",
             system_prompt: str = None,
             query_wrapper_prompt: Union[str, BasePromptTemplate] = None,
             enable_cost_calculator: bool = False,
@@ -33,7 +33,7 @@ class AutoServiceContext:
 
         Parameters:
             llm (LLM): The LLM to use for the query engine. Defaults to gp3-5-turbo.
-            embed_model (BaseEmbedding): The embedding model to use for the query engine.
+            embed_model (BaseEmbedding): The embedding model to use for the query engine. Defaults to OpenAIEmbedding.
             system_prompt (str): The system prompt to use for the query engine.
             query_wrapper_prompt (Union[str, BasePromptTemplate]): The query wrapper prompt to use for the query engine.
             cost_calculator_verbose (bool): Flag to enable cost calculator logging.
@@ -53,9 +53,6 @@ class AutoServiceContext:
         if enable_cost_calculator:
             model = llm.metadata.model_name if not "default" else "gpt-3.5-turbo"
             callback_manager.add_handler(CostCalculatingHandler(model=model, verbose=True))
-
-        if embed_model is None:
-            embed_model = OpenAIEmbedding()
 
         service_context = ServiceContext.from_defaults(
             llm=llm,

--- a/autollm/auto/service_context.py
+++ b/autollm/auto/service_context.py
@@ -32,7 +32,7 @@ class AutoServiceContext:
         enable_token_counting is True, tracks the number of tokens used by the LLM for each query.
 
         Parameters:
-            llm (LLM): The LLM to use for the query engine. Defaults to gp3-5-turbo.
+            llm (LLM): The LLM to use for the query engine. Defaults to gpt-3.5-turbo.
             embed_model (BaseEmbedding): The embedding model to use for the query engine. Defaults to OpenAIEmbedding.
             system_prompt (str): The system prompt to use for the query engine.
             query_wrapper_prompt (Union[str, BasePromptTemplate]): The query wrapper prompt to use for the query engine.


### PR DESCRIPTION
This PR adjusts the embedding selection process to use local embeddings when no OpenAI API key is provided. The update enhances the user experience by ensuring that the system continues to function with local embeddings as a fallback.
