### PR TITLE
fix from_config method of AutoQueryEngine

### DIFF
--- a/autollm/auto/query_engine.py
+++ b/autollm/auto/query_engine.py
@@ -154,6 +154,8 @@ class AutoQueryEngine:
         """
 
         config = load_config_and_dotenv(config_file_path, env_file_path)
+        # Get the first task configuration
+        config = config['tasks'][0]
 
         return create_query_engine(
             documents=documents,


### PR DESCRIPTION
This change ensures that `AutoQueryEngine.from_config` correctly extracts and applies the first task configuration from the YAML file, avoiding any potential ambiguity or errors when multiple tasks are defined but only one is expected by the engine.