### PR TITLE
integrate langchain pdf reader

### DIFF
--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -31,7 +31,7 @@ def read_files_as_documents(
         input_files (List): List of file paths.
         filename_as_id (bool): Whether to use the filename as the document id.
         recursive (bool): Whether to recursively search for files in the input directory.
-        required_exts (Optional[List[str]]): List of required extensions.
+        required_exts (Optional[List[str]]): List of file extensions to be read. Defaults to all supported extensions.
         read_as_single_doc (bool): If True, read each markdown as a single document.
 
     Returns:

--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -5,11 +5,12 @@ import stat
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
-from llama_index.readers.file.base import SimpleDirectoryReader
+from llama_index.readers.file.base import DEFAULT_FILE_READER_CLS, SimpleDirectoryReader
 from llama_index.schema import Document
 
 from autollm.utils.git_utils import clone_or_pull_repository
 from autollm.utils.multimarkdown_reader import MultiMarkdownReader
+from autollm.utils.pdf_reader import LangchainPDFReader
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,10 @@ def read_files_as_documents(
         documents (Sequence[Document]): A sequence of Document objects.
     """
     # Configure file_extractor to use MultiMarkdownReader for md files
-    file_extractor = {".md": MultiMarkdownReader(read_as_single_doc=read_as_single_doc)}
+    file_extractor = {
+        **DEFAULT_FILE_READER_CLS, ".md": MultiMarkdownReader(read_as_single_doc=read_as_single_doc),
+        ".pdf": LangchainPDFReader(extract_images=False)
+    }
 
     # Initialize SimpleDirectoryReader
     reader = SimpleDirectoryReader(

--- a/autollm/utils/pdf_reader.py
+++ b/autollm/utils/pdf_reader.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from langchain.document_loaders import PDFMinerLoader
+from llama_index.readers.base import BaseReader
+from llama_index.schema import Document
+
+
+class LangchainPDFReader(BaseReader):
+    """Custom PDF reader that uses langchain's PDFMinerLoader."""
+
+    def __init__(self, extract_images: bool = True) -> None:
+        """Initialize the reader."""
+        self.extract_images = extract_images
+
+    def load_data(self, file_path: str, extra_info: dict = None) -> List[Document]:
+        """Load data from a PDF file using langchain's PDFMinerLoader."""
+        # Convert the PosixPath object to a string before passing it to PDFMinerLoader
+        loader = PDFMinerLoader(str(file_path), extract_images=self.extract_images)
+        langchain_documents = loader.load()  # This returns a list of langchain Document objects
+
+        # Convert langchain documents into llama-index documents
+        documents = []
+        for langchain_document in langchain_documents:
+            # Create a llama-index document for each langchain document
+            doc = Document.from_langchain_format(langchain_document)
+
+            # If there's extra info, we can add it to the Document's metadata
+            if extra_info is not None:
+                doc.metadata.update(extra_info)
+
+            documents.append(doc)
+
+        return documents

--- a/autollm/utils/pdf_reader.py
+++ b/autollm/utils/pdf_reader.py
@@ -8,7 +8,7 @@ from llama_index.schema import Document
 class LangchainPDFReader(BaseReader):
     """Custom PDF reader that uses langchain's PDFMinerLoader."""
 
-    def __init__(self, extract_images: bool = True) -> None:
+    def __init__(self, extract_images: bool = False) -> None:
         """Initialize the reader."""
         self.extract_images = extract_images
 


### PR DESCRIPTION
This PR replaces the default PDFReader with Langchain's PDFMinerLoader for enhanced PDF processing capabilities. It includes the necessary changes to convert langchain documents to the llama-index document format, ensuring compatibility with our `read_files_as_documents` and `read_github_repo_as_documents` methods

The update has been tested and confirmed to work seamlessly with the existing system.
