### PR TITLE
add tutorials section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
     </a>
   </p>
 
+<br>
+
+[questions](https://github.com/safevideo/autollm/discussions/categories/q-a) | [feature requests](https://github.com/safevideo/autollm/discussions/categories/feature-requests)
+
+<br>
+
 [![version](https://badge.fury.io/py/autollm.svg)](https://badge.fury.io/py/autollm)
 <a href="https://pepy.tech/project/autollm"><img src="https://pepy.tech/badge/autollm" alt="total autollm downloads"></a>
 [![license](https://img.shields.io/pypi/l/autollm)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ______________________________________________________________________
 
 - **video tutorials**:
 
-  - [Make RAG with API Just in a few Seconds!!!](https://www.youtube.com/watch?v=sgKpBMGC6M0&list=LL&index=2) -
+  - [Make RAG with API Just in a few Seconds!!!](https://www.youtube.com/watch?v=sgKpBMGC6M0&list=LL&index=2)
   - [Autollm automagically create llm apps in seconds](https://www.youtube.com/watch?v=HZik9309wQc&list=LL&index=3)
 
 - **blog posts**:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ ______________________________________________________________________
 
 ## 🎯 quickstart
 
+### tutorials
+
+- **video tutorials**:
+
+  - [Make RAG with API Just in a few Seconds!!!](https://www.youtube.com/watch?v=sgKpBMGC6M0&list=LL&index=2) -
+  - [Autollm automagically create llm apps in seconds](https://www.youtube.com/watch?v=HZik9309wQc&list=LL&index=3)
+
+- **blog posts**:
+
+  - [Introduction to AutoLLM](https://abrahimzaman360.medium.com/introduction-to-autollm-c8cd31be2a5f)
+
+- **colab notebooks**:
+
+  - quickstart: [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/safevideo/autollm/blob/main/examples/quickstart.ipynb)
+
 ### create a query engine in seconds
 
 ```python


### PR DESCRIPTION
This PR introduces a new `tutorials` section under `quickstart` in the README. It provides users with additional resources including video tutorials, a Medium blog post, and a quickstart colab notebook to facilitate a better understanding of `autollm`.