### PR TITLE
add web documentation pages reader and web page reader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
       - name: Update pip
         run: python -m pip install --upgrade pip
 
-      - name: Install local package with dev dependencies
+      - name: Install local package with dev and readers dependencies
         run: >
-          pip install -e .[dev]
+          pip install -e .[dev,readers]
 
       - name: Check styling with pre-commit
         run: |

--- a/autollm/utils/db_utils.py
+++ b/autollm/utils/db_utils.py
@@ -5,10 +5,7 @@ from typing import Sequence
 from llama_index import Document, StorageContext, VectorStoreIndex
 from llama_index.vector_stores import PineconeVectorStore, QdrantVectorStore
 
-from autollm.auto.vector_store_index import AutoVectorStoreIndex
-from autollm.utils.constants import DEFAULT_INDEX_NAME
 from autollm.utils.env_utils import read_env_variable
-from autollm.utils.hash_utils import check_for_changes
 
 logger = logging.getLogger(__name__)
 

--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -11,6 +11,7 @@ from llama_index.schema import Document
 from autollm.utils.git_utils import clone_or_pull_repository
 from autollm.utils.multimarkdown_reader import MultiMarkdownReader
 from autollm.utils.pdf_reader import LangchainPDFReader
+from autollm.utils.web_docs_reader import WebDocsReader
 
 logger = logging.getLogger(__name__)
 
@@ -111,4 +112,19 @@ def read_github_repo_as_documents(
         # Delete the temporary directory
         shutil.rmtree(temp_dir, onerror=on_rm_error)
 
+    return documents
+
+
+def read_web_as_documents(url: str) -> List[Document]:
+    """
+    Read documents from a web URL using the WebDocsReader.
+
+    Parameters:
+        url (str): The starting URL from which to scrape documents.
+
+    Returns:
+        List[Document]: A list of Document objects containing content and metadata from the web pages.
+    """
+    reader = WebDocsReader()
+    documents = reader.load_data(url)
     return documents

--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -9,7 +9,7 @@ from llama_index.readers.file.base import SimpleDirectoryReader
 from llama_index.schema import Document
 
 from autollm.utils.git_utils import clone_or_pull_repository
-from autollm.utils.multimarkdown_reader import MultiMarkdownReader
+from autollm.utils.multimarkdown_reader import MarkdownReader
 from autollm.utils.pdf_reader import LangchainPDFReader
 from autollm.utils.web_docs_reader import WebDocsReader
 
@@ -38,16 +38,17 @@ def read_files_as_documents(
     Returns:
         documents (Sequence[Document]): A sequence of Document objects.
     """
-    # Configure file_extractor to use MultiMarkdownReader for md files
+    # Configure file_extractor to use MarkdownReader for md files
     file_extractor = {
-        ".md": MultiMarkdownReader(read_as_single_doc=True),
+        ".md": MarkdownReader(read_as_single_doc=True),
         ".pdf": LangchainPDFReader(extract_images=False)
     }
 
     # Initialize SimpleDirectoryReader
     reader = SimpleDirectoryReader(
-        file_extractor=file_extractor,
         input_dir=input_dir,
+        exclude_hidden=exclude_hidden,
+        file_extractor=file_extractor,
         input_files=input_files,
         filename_as_id=filename_as_id,
         recursive=recursive,

--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -19,10 +19,10 @@ logger = logging.getLogger(__name__)
 def read_files_as_documents(
         input_dir: Optional[str] = None,
         input_files: Optional[List] = None,
+        exclude_hidden: bool = True,
         filename_as_id: bool = True,
         recursive: bool = True,
         required_exts: Optional[List[str]] = None,
-        read_as_single_doc: bool = True,
         **kwargs) -> Sequence[Document]:
     """
     Process markdown files to extract documents using SimpleDirectoryReader.
@@ -30,17 +30,17 @@ def read_files_as_documents(
     Parameters:
         input_dir (str): Path to the directory containing the markdown files.
         input_files (List): List of file paths.
+        exclude_hidden (bool): Whether to exclude hidden files.
         filename_as_id (bool): Whether to use the filename as the document id.
         recursive (bool): Whether to recursively search for files in the input directory.
         required_exts (Optional[List[str]]): List of file extensions to be read. Defaults to all supported extensions.
-        read_as_single_doc (bool): If True, read each markdown as a single document.
 
     Returns:
         documents (Sequence[Document]): A sequence of Document objects.
     """
     # Configure file_extractor to use MultiMarkdownReader for md files
     file_extractor = {
-        ".md": MultiMarkdownReader(read_as_single_doc=read_as_single_doc),
+        ".md": MultiMarkdownReader(read_as_single_doc=True),
         ".pdf": LangchainPDFReader(extract_images=False)
     }
 

--- a/autollm/utils/document_reading.py
+++ b/autollm/utils/document_reading.py
@@ -5,7 +5,7 @@ import stat
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
-from llama_index.readers.file.base import DEFAULT_FILE_READER_CLS, SimpleDirectoryReader
+from llama_index.readers.file.base import SimpleDirectoryReader
 from llama_index.schema import Document
 
 from autollm.utils.git_utils import clone_or_pull_repository
@@ -40,7 +40,7 @@ def read_files_as_documents(
     """
     # Configure file_extractor to use MultiMarkdownReader for md files
     file_extractor = {
-        **DEFAULT_FILE_READER_CLS, ".md": MultiMarkdownReader(read_as_single_doc=read_as_single_doc),
+        ".md": MultiMarkdownReader(read_as_single_doc=read_as_single_doc),
         ".pdf": LangchainPDFReader(extract_images=False)
     }
 

--- a/autollm/utils/llm_utils.py
+++ b/autollm/utils/llm_utils.py
@@ -1,7 +1,5 @@
 import logging
 
-from llama_index.prompts import ChatMessage, ChatPromptTemplate, MessageRole
-
 from autollm.utils.templates import QUERY_PROMPT_TEMPLATE, SYSTEM_PROMPT
 
 logger = logging.getLogger(__name__)

--- a/autollm/utils/multimarkdown_reader.py
+++ b/autollm/utils/multimarkdown_reader.py
@@ -7,12 +7,6 @@ from autollm.utils.markdown_reader import MarkdownReader
 
 
 class MultiMarkdownReader(MarkdownReader):
-    """
-    MultiMarkdown parser.
-
-    Extract text from multiple markdown files. Returns a list of dictionaries with keys as headers and values
-    as the text between headers.
-    """
 
     def __init__(self, *args, read_as_single_doc: bool = False, **kwargs) -> None:
         """
@@ -30,7 +24,6 @@ class MultiMarkdownReader(MarkdownReader):
         extra_info: Optional[Dict] = None,
         content: Optional[str] = None,
     ) -> List[Document]:
-        """Include original_file_path in extra_info and respect read_as_single_doc flag."""
         if extra_info is None:
             extra_info = {}
 

--- a/autollm/utils/web_docs_reader.py
+++ b/autollm/utils/web_docs_reader.py
@@ -1,0 +1,97 @@
+from typing import List
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from llama_index.readers.base import BaseReader
+from llama_index.schema import Document
+
+# Constants for content selection and cleaning
+SELECTORS = [
+    "article.bd-article",
+    'article[role="main"]',
+    "div.md-content",
+    'div[role="main"]',
+    "div.container",
+    "div.section",
+    "article",
+    "main",
+]
+
+IGNORED_TAGS = [
+    "nav",
+    "aside",
+    "form",
+    "header",
+    "noscript",
+    "svg",
+    "canvas",
+    "footer",
+    "script",
+    "style",
+]
+
+
+class WebDocsReader(BaseReader):
+    """Custom reader for web documents using BeautifulSoup for parsing HTML."""
+
+    def __init__(self, selectors: List[str] = SELECTORS, ignored_tags: List[str] = IGNORED_TAGS) -> None:
+        """Initialize the reader."""
+        self.selectors = selectors
+        self.ignored_tags = ignored_tags
+        self.visited_links = set()
+
+    def _fetch_and_parse(self, url: str) -> BeautifulSoup:
+        """Fetch the content of the web page and return a BeautifulSoup object."""
+        response = requests.get(url)
+        response.raise_for_status(
+        )  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
+        return BeautifulSoup(response.text, "html.parser")
+
+    def _clean_content(self, soup: BeautifulSoup) -> str:
+        """Clean the soup object to extract relevant text, ignoring the specified tags."""
+        for tag in soup(self.ignored_tags):
+            tag.decompose()
+        text = " ".join(soup.stripped_strings)
+        return text
+
+    def _get_child_links(self, soup: BeautifulSoup, current_url: str) -> List[str]:
+        """Get all child links from the soup object, relative to the current_url."""
+        base_url = f"{urlparse(current_url).scheme}://{urlparse(current_url).netloc}"
+        return [
+            urljoin(base_url, a.get('href')) for a in soup.find_all('a', href=True)
+            if urlparse(a.get('href')).netloc == urlparse(base_url).netloc
+        ]
+
+    def _get_normalized_url(self, url: str) -> str:
+        """Normalize the URL to avoid duplicates due to query parameters or fragments."""
+        parsed_url = urlparse(url)
+        return parsed_url._replace(query="", fragment="").geturl()
+
+    def _recursive_link_collector(self, url: str, base_url: str, depth=0, max_depth=3) -> None:
+        """Recursively collect links from the given URL, with depth control."""
+        normalized_url = self._get_normalized_url(url)
+        if normalized_url in self.visited_links or depth > max_depth:
+            return
+        self.visited_links.add(normalized_url)
+        soup = self._fetch_and_parse(url)
+        for child_url in self._get_child_links(soup, url):
+            # We only follow links that lead to the same domain
+            if urlparse(child_url).netloc == urlparse(base_url).netloc:
+                self._recursive_link_collector(child_url, base_url, depth=depth + 1, max_depth=max_depth)
+
+    def load_data(self, url: str) -> List[Document]:
+        """Load data from the web documents starting from the given URL."""
+        parsed_url = urlparse(url)
+        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        self._recursive_link_collector(url, base_url)
+        documents = []
+        for url in self.visited_links:
+            soup = self._fetch_and_parse(url)
+            for selector in self.selectors:
+                content = soup.select_one(selector)
+                if content:
+                    text_content = self._clean_content(content)
+                    documents.append(Document(content=text_content, metadata={"url": url}))
+                    break
+        return documents

--- a/autollm/utils/web_page_reader.py
+++ b/autollm/utils/web_page_reader.py
@@ -1,0 +1,71 @@
+from typing import List
+from urllib.parse import urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from llama_index.schema import Document
+
+# Selectors to identify the main content of the page
+SELECTORS = [
+    "article.bd-article",
+    'article[role="main"]',
+    "div.md-content",
+    'div[role="main"]',
+    "div.container",
+    "div.section",
+    "article",
+    "main",
+]
+
+# Tags to ignore while extracting content
+IGNORED_TAGS = [
+    "nav",
+    "aside",
+    "form",
+    "header",
+    "noscript",
+    "svg",
+    "canvas",
+    "footer",
+    "script",
+    "style",
+]
+
+
+class WebPageReader:
+    """Class to read and process content from a single web page."""
+
+    def load_data(self, url: str) -> List[Document]:
+        """
+        Load and process content from the given URL.
+
+        Args:
+            url (str): The URL of the web page to process.
+
+        Returns:
+            List[Document]: A list containing a single Document object with the processed content.
+        """
+        response = requests.get(url)
+        if response.status_code != 200:
+            raise ValueError(f"Failed to fetch the website: {response.status_code}")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        content = None
+        for selector in SELECTORS:
+            element = soup.select_one(selector)
+            if element:
+                content = element.prettify()
+                break
+        if content is None:
+            content = soup.get_text()
+
+        # Clean the content by removing ignored tags
+        soup = BeautifulSoup(content, "html.parser")
+        for tag in soup(IGNORED_TAGS):
+            tag.decompose()
+
+        content_cleaned = " ".join(soup.stripped_strings)
+        document = Document(text=content_cleaned, metadata={"url": url})
+
+        return [document]

--- a/autollm/utils/web_page_reader.py
+++ b/autollm/utils/web_page_reader.py
@@ -1,11 +1,11 @@
+import logging
 from typing import List
-from urllib.parse import urlparse
 
 import requests
 from bs4 import BeautifulSoup
 from llama_index.schema import Document
 
-# Selectors to identify the main content of the page
+# Constants defined outside the class
 SELECTORS = [
     "article.bd-article",
     'article[role="main"]',
@@ -17,7 +17,6 @@ SELECTORS = [
     "main",
 ]
 
-# Tags to ignore while extracting content
 IGNORED_TAGS = [
     "nav",
     "aside",
@@ -31,41 +30,48 @@ IGNORED_TAGS = [
     "style",
 ]
 
+logger = logging.getLogger(__name__)
+
 
 class WebPageReader:
-    """Class to read and process content from a single web page."""
+    """A class for reading and processing the content of a single web page."""
 
     def load_data(self, url: str) -> List[Document]:
         """
-        Load and process content from the given URL.
+        Reads a web page from the provided URL, extracts content using predefined selectors, removes all
+        ignored tags, and returns a list of Document objects with the processed content.
 
-        Args:
-            url (str): The URL of the web page to process.
+        Parameters:
+            url (str): The URL of the web page to read.
 
         Returns:
-            List[Document]: A list containing a single Document object with the processed content.
+            List[Document]: A list containing Document objects with the processed content and its metadata.
         """
         response = requests.get(url)
         if response.status_code != 200:
-            raise ValueError(f"Failed to fetch the website: {response.status_code}")
+            logger.info(f"Failed to fetch the website: {response.status_code}")
+            return []
 
         soup = BeautifulSoup(response.content, "html.parser")
 
-        content = None
         for selector in SELECTORS:
             element = soup.select_one(selector)
             if element:
                 content = element.prettify()
                 break
-        if content is None:
+        else:
+            logger.info(f"Failed to find any element for URL: {url}")
             content = soup.get_text()
 
-        # Clean the content by removing ignored tags
         soup = BeautifulSoup(content, "html.parser")
         for tag in soup(IGNORED_TAGS):
             tag.decompose()
 
-        content_cleaned = " ".join(soup.stripped_strings)
-        document = Document(text=content_cleaned, metadata={"url": url})
-
+        content = " ".join(soup.stripped_strings)
+        document = Document(text=content, metadata={"url": url})
         return [document]
+
+
+# Example of usage:
+# reader = WebPageReader()
+# documents = reader.load_data('http://example.com/some-page')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pre-commit==3.4.0
+pytest==7.4.2

--- a/readers-requirements.txt
+++ b/readers-requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4==4.12.2

--- a/readers-requirements.txt
+++ b/readers-requirements.txt
@@ -1,1 +1,3 @@
 beautifulsoup4==4.12.2
+pdfminer.six==20221105
+gitpython==3.1.37

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import io
 import os
 import re
 

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,21 @@ import re
 
 import setuptools
 
-DEV_REQUIREMETNS = [
-    'pre-commit==3.4.0',
-    'pytest==7.4.2',
-]
+
+def get_requirements(req_path: str):
+    with open(req_path, encoding='utf8') as f:
+        return f.read().splitlines()
+
+
+INSTALL_REQUIRES = get_requirements("requirements.txt")
+DEV_REQUIREMETNS = get_requirements("dev-requirements.txt")
+READERS_REQUIREMENTS = get_requirements("readers-requirements.txt")
 
 
 def get_long_description():
     base_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(base_dir, 'README.md'), encoding='utf-8') as f:
         return f.read()
-
-
-def get_requirements():
-    with open('requirements.txt', encoding='utf8') as f:
-        return f.read().splitlines()
 
 
 def get_version():
@@ -53,8 +53,11 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/safevideo/autollm',
     packages=setuptools.find_packages(exclude=["tests", "examples"]),
-    install_requires=get_requirements(),
-    extras_require={'dev': DEV_REQUIREMETNS},
+    install_requires=INSTALL_REQUIRES,
+    extras_require={
+        'dev': DEV_REQUIREMETNS,
+        'readers': READERS_REQUIREMENTS
+    },
     python_requires='>=3.8',
     classifiers=[
         'Intended Audience :: Developers', 'Intended Audience :: Information Technology',

--- a/tests/test_auto_query_engine.py
+++ b/tests/test_auto_query_engine.py
@@ -1,4 +1,4 @@
-from llama_index import Document, ServiceContext, VectorStoreIndex
+from llama_index import Document, VectorStoreIndex
 from llama_index.query_engine import BaseQueryEngine
 
 from autollm.auto.query_engine import AutoQueryEngine


### PR DESCRIPTION
This PR introduces the `read_web_as_documents` function, which enables the scraping of web documents to be processed as `Document` objects by our system. It utilizes the newly developed `WebDocsReader` class for parsing HTML and extracting relevant content. This feature expands our document ingestion capabilities to include web content, broadening the utility and reach of our tool.