### PR TITLE
Update llama-index to latest commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-llama-index @ git+https://github.com/fcakyon/llama_index@fix-litellm
+llama-index @ git+https://github.com/run-llama/llama_index@d47424ef82b25e2d266d19d7706cafaeee00533a
 litellm==1.1.1
 uvicorn
 fastapi


### PR DESCRIPTION
This pull request updates the llama-index dependency to the latest commit (d47424ef82b25e2d266d19d7706cafaeee00533a) from the repository run-llama/llama_index. This update ensures that the codebase is using the most recent version of llama-index.