### PR TITLE
implement lazy import for langchain in pdfreader

### DIFF
--- a/autollm/__init__.py
+++ b/autollm/__init__.py
@@ -4,7 +4,7 @@ This package provides automated integrations with leading large language models
 and vector databases, along with various utility functions.
 """
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'safevideo'
 __license__ = 'AGPL-3.0'
 

--- a/autollm/utils/pdf_reader.py
+++ b/autollm/utils/pdf_reader.py
@@ -1,6 +1,5 @@
 from typing import List
 
-from langchain.document_loaders import PDFMinerLoader
 from llama_index.readers.base import BaseReader
 from llama_index.schema import Document
 
@@ -16,6 +15,8 @@ class LangchainPDFReader(BaseReader):
 
     def load_data(self, file_path: str, extra_info: dict = None) -> List[Document]:
         """Load data from a PDF file using langchain's PDFMinerLoader."""
+        from langchain.document_loaders import PDFMinerLoader
+
         # Convert the PosixPath object to a string before passing it to PDFMinerLoader
         loader = PDFMinerLoader(str(file_path), extract_images=self.extract_images)
 


### PR DESCRIPTION
This PR introduces lazy importing for the `langchain` module within the `document_reading` module at `LangchainPDFReader` class. This change ensures that `langchain` is only imported when the `read_files_as_documents` method is used with `.pdf` files, thereby preventing it from being a mandatory dependency for the entire package. This approach improves the modularity and reduces the initial load time of our package, making it more efficient for users who do not require the `LangchainPDFReader` functionality.
