### PR TITLE
fix syntax errors in quickstart colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ______________________________________________________________________
 ```python
 >>> from autollm import AutoQueryEngine, read_files_as_documents
 
->>> documents = read_files_as_documents(input_dir="examples/data")
+>>> documents = read_files_as_documents(input_dir="path/to/documents")
 >>> query_engine = AutoQueryEngine.from_defaults(documents)
 
 >>> response = query_engine.query(

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -209,8 +209,8 @@
    "source": [
     "# llm params\n",
     "llm_model = \"gpt-3.5-turbo\"\n",
-    "llm_max_tokens = 512,\n",
-    "llm_temperature = 0.1,\n",
+    "llm_max_tokens = 512\n",
+    "llm_temperature = 0.1\n",
     "\n",
     "# service_context_params\n",
     "system_prompt = \"\"\"\n",
@@ -228,10 +228,10 @@
     "Query: {query_str}\n",
     "Answer:\n",
     "'''\n",
-    "enable_cost_calculator = True,\n",
-    "embed_model = \"default\",  # [\"default\", \"local\"]\n",
-    "chunk_size = 512,\n",
-    "context_window = 4096,\n",
+    "enable_cost_calculator = True\n",
+    "embed_model = \"default\"  # [\"default\", \"local\"]\n",
+    "chunk_size = 512\n",
+    "context_window = 4096\n",
     "\n",
     "# vector store params\n",
     "vector_store_type = \"LanceDBVectorStore\"\n",
@@ -398,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What's Changed:
- In the `llm params` section, unnecessary commas after `llm_max_tokens`, `llm_temperature`, and `enable_cost_calculator` have been removed. These commas were causing the variables to be interpreted as tuples, leading to errors.
- Similarly, in the `service_context_params` section, the comma after `embed_model` was removed for the same reason.

## Why:
These changes correct the syntax errors that were causing interpretation issues, ensuring that the variables are correctly identified as integers and strings, not tuples. This fix will resolve the errors and improve the stability of the notebook.
