### PR TITLE
Update readers-requirements.txt

### DIFF
--- a/readers-requirements.txt
+++ b/readers-requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.12.2
 pdfminer.six==20221105
-gitpython==3.1.37
+gitpython==3.1.41
 docx2txt
 EbookLib
 html2text


### PR DESCRIPTION
Because of dependabot security alert:

Untrusted search path under some conditions on Windows allows arbitrary code execution #1
 Open Opened 3 hours ago on GitPython (pip) · [readers-requirements.txt](https://github.com/safevideo/autollm/blob/-/readers-requirements.txt)
Upgrade GitPython to fix [1 Dependabot alert](https://github.com/safevideo/autollm/security/dependabot?q=is%3Aopen+package%3AGitPython+manifest%3Areaders-requirements.txt+has%3Apatch) in [readers-requirements.txt](https://github.com/safevideo/autollm/blob/-/readers-requirements.txt)
Upgrade GitPython to version 3.1.41 or later. For example:

GitPython>=3.1.41